### PR TITLE
Bug fix when trying to deploy metrics to an unpublished app.:

### DIFF
--- a/lib/publishMetrics.js
+++ b/lib/publishMetrics.js
@@ -43,6 +43,10 @@ var publishMetrics =
             })
             .then(function(arrObjects)
             {
+                if (arrObjects == undefined)
+                {
+                    return;
+                }
                 return Promise.all(arrObjects.map(function(appObjectId)
                 {
                     var putPath = "/app/object/" + appObjectId + "/publish";


### PR DESCRIPTION
GMS won't deploy when you have unpublished apps subscribing to governed metrics.

this is a bugfix. Take a look @goldbergjeffrey 