### PR TITLE
Enhance error message

### DIFF
--- a/lib/dowork.js
+++ b/lib/dowork.js
@@ -89,7 +89,7 @@ var doWork = {
             {
                 if(tags.body.length == 0)
                 {
-                    reject(new Error("Tag does not exist, shutting down run. Check that you have created a GMS tag http://eapowertools.github.io/GovernedMetricsService/user-guide/qsconfig/#step-4-create-a-gms-tag-to-mark-dimensions-and-measures"));
+                    reject(new Error("Tag does not exist, shutting down run. GMS tag needs to be lowercase. Read more in the docs http://eapowertools.github.io/GovernedMetricsService/user-guide/qsconfig/#step-4-create-a-gms-tag-to-mark-dimensions-and-measures"));
                 }
 				else
 				{

--- a/lib/dowork.js
+++ b/lib/dowork.js
@@ -89,7 +89,7 @@ var doWork = {
             {
                 if(tags.body.length == 0)
                 {
-                    reject(new Error("Tag does not exist, shutting down run. GMS tag needs to be lowercase. Read more in the docs http://eapowertools.github.io/GovernedMetricsService/user-guide/qsconfig/#step-4-create-a-gms-tag-to-mark-dimensions-and-measures"));
+                    reject(new Error("Tag does not exist, shutting down run. Create a tag labeled gms in the QMC.  The tag needs to be lowercase. Read more in the docs http://eapowertools.github.io/GovernedMetricsService/user-guide/qsconfig/#step-4-create-a-gms-tag-to-mark-dimensions-and-measures"));
                 }
 				else
 				{

--- a/lib/dowork.js
+++ b/lib/dowork.js
@@ -89,7 +89,7 @@ var doWork = {
             {
                 if(tags.body.length == 0)
                 {
-                    reject(new Error("Tag does not exist, shutting down run."));
+                    reject(new Error("Tag does not exist, shutting down run. Check that you have created a GMS tag http://eapowertools.github.io/GovernedMetricsService/user-guide/qsconfig/#step-4-create-a-gms-tag-to-mark-dimensions-and-measures"));
                 }
 				else
 				{


### PR DESCRIPTION
If a user tries runs updateAll without a tag created in the QMC, suggest creating the tag in the error message.