### PR TITLE
added logic to handle when repo service is not started

### DIFF
--- a/lib/notifyFactory.js
+++ b/lib/notifyFactory.js
@@ -7,11 +7,45 @@ var Promise = require('bluebird');
 
 
 var notifyFactory = {
-    getUpdateHandle: function() {
-    return new Promise(function(resolve, reject)
-    {
+
+    checkQRSConnection: function() {
+        return new Promise(function(resolve, reject) {
+            var path = "/app";
+            qrsNotify.qrsAlive(path)
+                .then(function(result) {
+                    return getUpdateHandle()
+                        .then(function(result) {
+                            return getDeleteHandle()
+                                .then(function(result) {
+                                    resolve("SUCCESS");
+                                })
+                                .catch(function(error) {
+                                    reject(error);
+                                });
+                        })
+                        .catch(function(error) {
+                            reject(error);
+                        });
+                })
+                .catch(function(error)
+                {
+                    logger.debug("here")
+                    logger.debug(error.stack);
+                    reject(error);
+                })
+
+        });
+    }
+
+};
+
+
+module.exports = notifyFactory;
+
+function getUpdateHandle() {
+    return new Promise(function(resolve, reject) {
         var updateHandleFile = path.normalize(path.join(__dirname, "/../config/updateHandleFile.txt"));
-        
+
         logger.info("Deleting current notification service handle for GMS based changes", { module: 'server' });
         if (fs.existsSync(updateHandleFile)) {
             var handle = fs.readFileSync(updateHandleFile).toString().split('\n');
@@ -42,10 +76,10 @@ var notifyFactory = {
                 });
         }
     });
-    },
-    getDeleteHandle: function() {
-        return new Promise(function(resolve, reject)
-        {
+}
+
+function getDeleteHandle() {
+    return new Promise(function(resolve, reject) {
         var deleteHandleFile = path.normalize(path.join(__dirname, "/../config/deleteHandleFile.txt"));
         if (fs.existsSync(deleteHandleFile)) {
             var handle = fs.readFileSync(deleteHandleFile).toString().split('\n');
@@ -75,13 +109,8 @@ var notifyFactory = {
                     reject(error);
                 });
         }
-        });
-    }
-
-};
-
-
-module.exports = notifyFactory;
+    });
+}
 
 function createUpdateNotification(handleFile) {
     return new Promise(function(resolve, reject) {

--- a/lib/qrsNotify.js
+++ b/lib/qrsNotify.js
@@ -34,7 +34,50 @@ var qrsNotify = {
                     reject(error);
                 });
         });
+    },
+    qrsAlive: function(path, pingCount) {
+        pingCount = pingCount || 0;
+        var boolFailed= false;
+        
+       return new Promise(function(resolve, reject) {
+           logger.debug(pingCount);
+           if (pingCount > 12) {
+            
+            reject("Failed connection to repository too many times");
+           }
+            logger.debug("Checking to see if Qlik Repository Service is running", { module: 'qrsNotify', method: 'qrsAlive' });
+            qrsInteract.Get(path)
+                .then(function(result) {
+                    logger.debug("Ping Successful");
+                    resolve(true)
+                })
+                .catch(function(error) {
+                    resolve(false);
+                })
+       })
+       .then(function(foo)
+        {
+            if(foo)
+            {
+                return foo;
+            }
+            else {
+               return sleep(10000)
+                .then(function()
+                    {
+                        return qrsNotify.qrsAlive(path, pingCount + 1)
+                    }
+                );
+            }
+    
+        })
     }
 };
 
 module.exports = qrsNotify;
+
+// https://zeit.co/blog/async-and-await
+function sleep (time) {
+  return new Promise(function(resolve) {setTimeout(resolve, time)});
+}
+

--- a/server.js
+++ b/server.js
@@ -22,18 +22,18 @@ var x = {};
 
 logger.info('Firing up the Governed Metrics Service ReST API', { module: 'server' });
 
-notifyFactory.getUpdateHandle()
+
+notifyFactory.checkQRSConnection()
     .then(function(result) {
-        return notifyFactory.getDeleteHandle()
-            .then(function(result) {
-                launchServer();
-            })
-            .catch(function(error) {
-                logger.error(JSON.stringify(error), { module: "server" });
-                process.exit();
-            });
+        if (result === "SUCCESS") {
+            return launchServer();
+        } else {
+            logger.error(JSON.stringify(result), { module: "server" });
+            process.exit();
+        }
     })
     .catch(function(error) {
+        logger.error("Shutting down GMS.  Can't Start Up");
         logger.error(JSON.stringify(error), { module: "server" });
         process.exit();
     });


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Added a timer to retry a repository service connection to make sure the notification agents for GMS are added when the Qlik Sense services restart.  In the event the services are restarted, the EA Powertools service will need to be restarted as well to handle setting new notification agents for GMS.

### Benefits

On a server boot up, GMS will wait up to two minutes to start and will fail if the repository service does not respond in that time frame.

### Possible Drawbacks

Does not resolve instances where Qlik Sense repository service is stopped and started manually.  I the event this happens, the EAPowertools Service Dispatcher service will need to be restarted so that the GMS can obtain new notification agent references for creating objects and deleting objects.
